### PR TITLE
Release/4.6.7

### DIFF
--- a/src/quadpype/hosts/aftereffects/api/launch_logic.py
+++ b/src/quadpype/hosts/aftereffects/api/launch_logic.py
@@ -82,7 +82,7 @@ def main(*subprocess_args):
     sys.exit(app.exec_())
 
 
-def show_tool_by_name(tool_name, tab_name):
+def show_tool_by_name(tool_name, tab_name=None):
     kwargs = {}
     if tool_name == "loader":
         kwargs["use_context"] = True

--- a/src/quadpype/hosts/photoshop/api/launch_logic.py
+++ b/src/quadpype/hosts/photoshop/api/launch_logic.py
@@ -107,7 +107,7 @@ def stub():
     return ps_stub
 
 
-def show_tool_by_name(tool_name, tab_name):
+def show_tool_by_name(tool_name, tab_name=None):
     kwargs = {}
     if tool_name == "loader":
         kwargs["use_context"] = True

--- a/src/quadpype/version.py
+++ b/src/quadpype/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """File declaring QuadPype version."""
-__version__ = "4.6.6"
+__version__ = "4.6.7"


### PR DESCRIPTION
# Include

## Bugfix
- (After Effects) (Photoshop) Add optional flag to `tab_name` argument to ensure compatibility with previous calls ([PR](https://github.com/quadproduction/quadpype/pull/382))([Issue](https://github.com/quadproduction/quadpype/issues/334))